### PR TITLE
fix: d-day일수 오늘 포함으로 변경

### DIFF
--- a/src/components/ConfirmBox.jsx
+++ b/src/components/ConfirmBox.jsx
@@ -122,11 +122,15 @@ function ConfirmBox(props) {
     // D-Day 계산
     const calculateDDay = (eventDate) => {
         const today = new Date();
+        today.setHours(0, 0, 0, 0); // 오늘 날짜를 자정으로 설정
+    
         const eventDay = new Date(eventDate);
+        eventDay.setHours(0, 0, 0, 0); // 이벤트 날짜를 자정으로 설정
+    
         const timeDiff = eventDay - today;
         const dayDiff = timeDiff / (1000 * 60 * 60 * 24);
-
-        return Math.floor(dayDiff);
+    
+        return Math.ceil(dayDiff); // 오늘을 포함하려면 올림을 사용
     };
 
     const dDay = calculateDDay(date);
@@ -141,9 +145,9 @@ function ConfirmBox(props) {
             
             <MarkContainer>
                 {userRole === 'host' ? (
-                    <BsFillBookmarkStarFill />
+                    <BsFillBookmarkStarFill size={24}/>
                     ) : (
-                    <BsFillBookmarkPlusFill />
+                    <BsFillBookmarkPlusFill size={24}/>
                 )}
             </MarkContainer>
         </DNMContainer>

--- a/src/db/confirmdata.json
+++ b/src/db/confirmdata.json
@@ -14,7 +14,7 @@
         "박지환",
         "유지희"
       ],
-      "userRole": "participant"
+      "userRole": "host"
     },
     {
       "id": 2,
@@ -28,7 +28,7 @@
         "김경재",
         "유지희"
       ],
-      "userRole": "host"
+      "userRole": "participant"
     },
     {
       "id": 3,
@@ -52,13 +52,14 @@
         "date": "2024-04-15",
         "time": "09:30",
         "place": "외대식당",
-        "host": "유지희",
+        "host": "김경재",
         "participants": [
+          "유지희",
           "김현아",
           "문성욱",
           "박지환"
         ],
-        "userRole": "participant"
+        "userRole": "host"
       }
   ]
   


### PR DESCRIPTION
## Changes 📝

<!-- 이 PR에서 작업한 사항을 적어주세요. -->

-   밥약이 3/23일이면 3/20일 기준으로 d-3으로 떠야하는데 d-2로 뜨는 문제 수정
-  파티장인지 파티원인지 구분하는 마크 크기 24px로 수정

## Screenshot 📷

<img width="328" alt="image" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_11_FE/assets/118183190/9df208d3-723d-4613-9fd3-6113ec5ff077">

## Issues 🚩

<!-- 이 PR과 연관된 Issue를 작성해주세요. 해당 PR이 Issue를 해결한다면 Issue도 꼭 닫아주세요! 연관 Issue가 없다면 작성하지 않으셔도 됩니다. -->

> 없음
