### PR TITLE
feat: MobileWrapper의 Header에 상단 텍스트 추가

### DIFF
--- a/src/MobileWrapper.jsx
+++ b/src/MobileWrapper.jsx
@@ -4,6 +4,7 @@ import routes from './routes.jsx';
 import { IoIosArrowBack } from 'react-icons/io';
 
 import ServiceLogoImage from './assets/images/service_logo.svg';
+import ServiceLogoCompactImage from './assets/images/rice_balloon_no_tail.svg';
 import RiceBalloonButton from './assets/images/rice_balloon_button.svg';
 import { useState, useEffect } from 'react';
 import classNames from 'classnames';
@@ -57,6 +58,13 @@ const BackButton = styled.button`
     }
 `;
 
+const Title = styled.p`
+    font-size: 22px;
+    font-weight: 700;
+
+    color: #fe5858;
+`;
+
 const Logo = styled.img`
     height: 40px;
     cursor: pointer;
@@ -107,6 +115,7 @@ const ButtonImage = styled.img``;
 
 const LOGO_DEFAULT = true;
 const FOOTER_DEFAULT = false;
+const HEADER_TITLE_DEFAULT = null;
 const BACKWARD_DEFAULT = '/';
 
 const MobileWrapper = ({}) => {
@@ -114,6 +123,7 @@ const MobileWrapper = ({}) => {
 
     const [showLogo, setLogo] = useState(LOGO_DEFAULT);
     const [showFooter, setFooter] = useState(FOOTER_DEFAULT);
+    const [headerTitle, setHeaderTitle] = useState(HEADER_TITLE_DEFAULT);
     const [backwardUrl, setBackwardUrl] = useState(BACKWARD_DEFAULT);
 
     const location = useLocation();
@@ -124,10 +134,12 @@ const MobileWrapper = ({}) => {
         if (find) {
             setLogo(find.logo ?? LOGO_DEFAULT);
             setFooter(find.footer ?? FOOTER_DEFAULT);
+            setHeaderTitle(find.title ?? HEADER_TITLE_DEFAULT);
             setBackwardUrl(find.previous ?? BACKWARD_DEFAULT);
         } else {
             setLogo(LOGO_DEFAULT);
             setFooter(FOOTER_DEFAULT);
+            setHeaderTitle(HEADER_TITLE_DEFAULT);
             setBackwardUrl(BACKWARD_DEFAULT);
         }
     }, [location]);
@@ -149,9 +161,17 @@ const MobileWrapper = ({}) => {
                     >
                         <IoIosArrowBack />
                     </BackButton>
+                    <Title>{headerTitle}</Title>
                     <Logo
-                        src={ServiceLogoImage}
-                        className={classNames({ hidden: !showLogo })}
+                        src={
+                            headerTitle === null
+                                ? ServiceLogoImage
+                                : ServiceLogoCompactImage
+                        }
+                        className={classNames({
+                            hidden: !showLogo,
+                            compact: headerTitle !== null,
+                        })}
                     />
                 </Header>
                 <Outlet />

--- a/src/pages/ScheduledEvent.jsx
+++ b/src/pages/ScheduledEvent.jsx
@@ -8,6 +8,7 @@ import {
     BsFillBookmarkStarFill,
     BsJournalText,
     BsQuestionCircleFill,
+    BsTagsFill,
 } from 'react-icons/bs';
 import BlockButton from '../components/BlockButton.jsx';
 import _TextInput from '../components/TextInput.jsx';
@@ -192,7 +193,7 @@ const ScheduledEvent = ({}) => {
                     value={isShowPayment}
                     onChange={(value) => setShowPayment(value)}
                 >
-                    <ContentHeader icon={<BsJournalText />} text="송금 메모" />
+                    <ContentHeader icon={<BsTagsFill />} text="송금 메모" />
                     <TextInput placeholder="송금 관련한 메모를 작성해주세요" />
                     <ContentHeader
                         icon={<BsCreditCard2BackFill />}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -36,18 +36,21 @@ const routes = [
         element: <PendingParty />,
         footer: true,
         name: '대기중인 밥약',
+        title: '대기중인 밥약',
     },
     {
         path: '/party/scheduled',
         element: <ScheduledEvent />,
         footer: true,
         name: '확정된 밥약',
+        title: '확정된 밥약',
     },
     {
         path: '/party/create',
         element: <CreateParty />,
         footer: true,
         name: '밥약 생성하기',
+        title: '밥약 만들기',
     },
     {
         path: '/confirmbab',
@@ -71,6 +74,7 @@ const routes = [
         path: '/successregister',
         element: <SuccessRegister />,
         logo: false,
+        previous: false,
         name: '회원가입 완료',
     },
     {
@@ -78,12 +82,14 @@ const routes = [
         element: <ShareBab />,
         footer: true,
         name: '밥약 생성_링크 공유하기',
+        title: '밥약 만들기',
     },
     {
         path: '/payment',
         element: <Payment />,
         footer: true,
         name: '송금 및 보은하기',
+        title: '송금 및 보은하기',
     },
 ];
 


### PR DESCRIPTION
## Changes 📝

<!-- 이 PR에서 작업한 사항을 적어주세요. -->

- MobileWrapper의 Header에 상단 텍스트 및 미니멀 로고 지원을 추가한다.
- routes.jsx에 상단 텍스트가 들어가는 페이지에 텍스트를 추가한다.

## Screenshot 📷

<!-- 작업한 사항을 스크린샷으로 찍을 수 있다면 (예: 신규 페이지 구현, 새로운 컴포넌트 구현) 스크린샷을 찍어서 올려주세요. 반드시 올릴 필요는 없습니다! -->

![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_11_FE/assets/35104213/1cd0b115-f48d-46b7-a13b-d6dc6c8b6b6d)
![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_11_FE/assets/35104213/d5c09de7-5973-4592-9992-902070ced63e)
![image](https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_11_FE/assets/35104213/0d427d62-f7f2-43a8-9ade-165f5994923e)


## Issues 🚩

<!-- 이 PR과 연관된 Issue를 작성해주세요. 해당 PR이 Issue를 해결한다면 Issue도 꼭 닫아주세요! 연관 Issue가 없다면 작성하지 않으셔도 됩니다. -->

> 없음
